### PR TITLE
Ignore MPLAB generated files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# MPLAB Generated Files
+.generated_files/
+Makefile
+
 # Prerequisites
 *.d
 


### PR DESCRIPTION
These are auto-generated and get in the way. They should be generated as part of the build and not checked in.