### PR TITLE
Add absl to project.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -6,3 +6,14 @@ http_archive(
     strip_prefix = "googletest-release-1.8.1",
     sha256 = "927827c183d01734cc5cfef85e0ff3f5a92ffe6188e0d18e909c5efebf28a0c7"
 )
+
+# This is a dependency of gtest for many of its targets. We don't strictly need
+# this, but it is important for being able to query strongly the dependencies on
+# gtest to exclude them for xc32 builds, since gtest is not compilable with
+# xc32.
+http_archive(
+  name = "com_google_absl",
+  sha256 = "aabf6c57e3834f8dc3873a927f37eaf69975d4b28117fc7427dfb1c661542a87",
+  urls = ["https://github.com/abseil/abseil-cpp/archive/98eb410c93ad059f9bba1bf43f5bb916fc92a5ea.zip"],
+  strip_prefix = "abseil-cpp-98eb410c93ad059f9bba1bf43f5bb916fc92a5ea",
+)


### PR DESCRIPTION
It's not strictly needed, but it allows for deep querying against gtest, and gtest depends on it in some cases.