### PR TITLE
Support a cross-compiled build using XC32.

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,9 @@
+# Use our custom-configured c++ toolchain.
+build:xc32 --crosstool_top=@rules_microchip//toolchain/xc32:xc32_suite
+
+# Use --cpu as a differentiator.
+build:xc32 --cpu=mcp32
+
+# Use the default Bazel C++ toolchain to build the tools used during the
+# build.
+build:xc32 --host_crosstool_top=@bazel_tools//tools/cpp:toolchain

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,44 @@ jobs:
           command: |
             bazel test //...
 
+  # Cross-compiles all relevant targets with the XC32 C++ compiler. This builds
+  # artifacts suitable for running on PIC microcontrollers.
+  #
+  # We don't run unit tests against xc32-compiled targets, since our tests are
+  # generally entirely run with gtest, which isn't runnable in an MCP32
+  # environment, and we don't have remote execution anyways for executing tests
+  # on a PIC controller.
+  build-xc32:
+    docker:
+      - image: gcc:9.2.0
+
+    steps:
+      - checkout
+
+      - run:
+          name: Update APT
+          command: |
+            apt update
+
+      - install-bazel
+
+      - run:
+          name: Build targets with MCP32 CPU target
+          # Tests depending on gtest are excluded, since gtest is not compilable
+          # for MCP32 platforms. Automated unit test are executed in the `test`
+          # job on a linux x86 architecture.
+          command: |
+            # Build the controller explicitly, since the controller is marked as
+            # manual.
+            # TODO(willjschmitt): Remove //:electric_vehicle_controller once the
+            #  target is included by cpu constraint instead of using manual
+            #  tags.
+            bazel build --config=xc32 --sandbox_debug \
+                $(bazel query '//... except (//... intersect allpaths(//..., @gtest//:gtest_main))') \
+                //:electric_vehicle_controller
+
 workflows:
   test:
     jobs:
       - test-x86
+      - build-xc32

--- a/BUILD
+++ b/BUILD
@@ -1,0 +1,29 @@
+_ELECTRIC_VEHICLE_CONTROLLER_PROCESSOR="32MK1024GPE100"
+
+# The main binary to run on the micro-controller. It is compiled specifically
+# for our PIC32MK microcontroller, with memory and peripheral settings compiled
+# into the binary.
+cc_binary(
+    name = "electric_vehicle_controller",
+    srcs = [
+        "main.cpp",
+        "config.h",
+    ],
+    # TODO(willjschmitt): Instead of using a manual tag, restrict this target by
+    #  a platform constraint for the MCP32 CPU.
+    tags = [
+        "manual",
+    ],
+    copts = [
+        "-mprocessor={}".format(_ELECTRIC_VEHICLE_CONTROLLER_PROCESSOR),
+    ],
+    linkopts = [
+        "-Wl,--defsym=_min_heap_size=0xF00",
+        "-mprocessor={}".format(_ELECTRIC_VEHICLE_CONTROLLER_PROCESSOR),
+    ],
+    deps = [
+        "//control:current_regulator",
+        "//induction_motor_controls:induction_motor_controller",
+        "@pic32mk_gp_dfp//:xc_headers",
+    ],
+)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -17,3 +17,19 @@ http_archive(
   urls = ["https://github.com/abseil/abseil-cpp/archive/98eb410c93ad059f9bba1bf43f5bb916fc92a5ea.zip"],
   strip_prefix = "abseil-cpp-98eb410c93ad059f9bba1bf43f5bb916fc92a5ea",
 )
+
+_RULES_MICROCHIP_COMMIT_SHA = "3c3829d63e929a58e5daa1da2d8433b6307f19eb"
+
+# git_repository is not compatible here, since the x-bit is dropped on our
+# wrapper scripts.
+http_archive(
+    name = "rules_microchip",
+    sha256 = "e321777fb191b8dd888953587e3a6b3a9dfc96c4b4dae98cea50789171603a81",
+    url = "https://github.com/willjschmitt/rules_microchip/archive/{}.zip".format(_RULES_MICROCHIP_COMMIT_SHA),
+    strip_prefix = "rules_microchip-{}".format(_RULES_MICROCHIP_COMMIT_SHA),
+)
+
+load("@rules_microchip//:deps.bzl", "microchip_repositories", "dfp_repositories")
+
+microchip_repositories()
+dfp_repositories()

--- a/induction_motor_controls/BUILD
+++ b/induction_motor_controls/BUILD
@@ -1,6 +1,9 @@
 cc_library(
   name = "induction_motor_controller",
   srcs = ["induction_motor_controller.cpp"],
+  visibility = [
+      "//:__pkg__",
+  ],
   hdrs = ["induction_motor_controller.h"],
   deps = [
     "//control:current_regulator",

--- a/main.cpp
+++ b/main.cpp
@@ -1,6 +1,14 @@
 #include "config.h"
 
-#include <xc.h>
+// TODO(willjschmitt): Installing in our headless environment is more
+//  complicated than a GUI IDE environment, so we are using the deprecated
+//  approach to including the specific per-device header. This should be changed
+//  once the Bazel toolchain can properly install the XC32 compiler as we would
+//  expect it on a headfull machine like a Windows desktop. Once completed, the
+//  xc.h header can be included instead of the specific device header.
+// #include <xc.h>
+#include "proc/p32mk1024gpe100.h"
+
 #include <sys/attribs.h>
 
 #include "control/current_regulator.h"


### PR DESCRIPTION
This cross-compiles the main function using xc32 in order to support deploying a hex file to the PIC microcontroller.